### PR TITLE
Fixed Maven resources config (based on Gradle script)

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -22,7 +22,7 @@
 			<plugin>
 				<groupId>com.github.eirslett</groupId>
 				<artifactId>frontend-maven-plugin</artifactId>
-				<version>0.0.23</version>
+				<version>0.0.24</version>
 				<executions>
 					<execution>
 						<id>install node and npm</id>
@@ -35,6 +35,13 @@
 					<execution>
 						<id>npm install</id>
 						<goals><goal>npm</goal></goals>
+					</execution>
+					<execution>
+						<id>jspm-install</id>
+						<goals><goal>npm</goal></goals>
+						<configuration>
+							<arguments>run jspm-install</arguments>
+						</configuration>
 					</execution>
 					<execution>
 						<id>npm build</id>
@@ -51,7 +58,7 @@
 				<executions>
 					<execution>
 						<id>copy-resources</id>
-						<phase>package</phase>
+						<phase>prepare-package</phase>
 						<goals>
 							<goal>copy-resources</goal>
 						</goals>


### PR DESCRIPTION
Hi.  I fixed the following issues with Maven 'install' on a clean checkout - note, Gradle script works fine:
- Execute the 'run jspm-install' command during prepare-resources.
- Copy static resources before packaging jar.
